### PR TITLE
don't render extra newline on end

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,4 @@
 language: node_js
 node_js:
-  - '0.10'
-  - '0.12'
   - '4.0'
   - '6.0'

--- a/index.js
+++ b/index.js
@@ -92,6 +92,7 @@ function createStream () {
       }
       if (diff[pos] > 0) {
         if (diff[pos] === 1) diffLine(prev[pos], lines[pos], bufs)
+        else if (pos === diff.length - 1) bufs.push(Buffer(lines[pos]))
         else bufs.push(Buffer(lines[pos] + '\n'))
       } else {
         bufs.push(MOVE_DOWN)


### PR DESCRIPTION
Prevents rendering an extra newline at the end of the stream. Especially useful on small screens. Thanks!